### PR TITLE
Make panorama button not look like a menu-button

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -598,7 +598,7 @@ function processWindow(win) {
                 event.preventDefault();
                 event.stopPropagation();
             }), false);
-            tabviewButton.setAttribute("type", "menu-button");    
+            if (getPref('useMenuButtonForPanoramaReplacement')) tabviewButton.setAttribute("type", "menu-button");    
             tabviewButton.appendChild(btnPopup);
             
             if (getPref('replacePanoramaButton')) {

--- a/libs/prefs.js
+++ b/libs/prefs.js
@@ -38,7 +38,8 @@
 const PREF_BRANCH = "extensions.tabgroupsmenu.";
 const PREFS = {
   openOnMouseOver: false,
-  replacePanoramaButton: false
+  replacePanoramaButton: false,
+  useMenuButtonForPanoramaReplacement: true
 };
 
 /**


### PR DESCRIPTION
added preference to not style the replaced panorama button like a menu-button (because that one is too large in small-size-toolbar-mode)
